### PR TITLE
Explicitly get the latest work state when updating heartbeat

### DIFF
--- a/django_celery_monitor/managers.py
+++ b/django_celery_monitor/managers.py
@@ -31,7 +31,7 @@ class WorkerStateQuerySet(ExtendedQuerySet):
             )
             if recent_worker_updates.exists():
                 # if yes, get the latest update and move on
-                obj = recent_worker_updates.get()
+                obj = recent_worker_updates.latest()
             else:
                 # if no, update the worker state and move on
                 obj, _ = self.select_for_update_or_create(


### PR DESCRIPTION
The previous update_heartbeat method assumed that, if there was a worker update within the update_freq for a given host, there would only be a single instance. However, we have seen cases in the wild where this was not the case. This code guards against this edge-case by using .latest() rather than .get().

---
Intended as a fix for [this issue](https://sentry.maykinmedia.nl/organizations/maykin-media/issues/385874/?project=427&query=is%3Aunresolved).